### PR TITLE
fix: resolve the installing issue in react hook form

### DIFF
--- a/src/utils/packages.js
+++ b/src/utils/packages.js
@@ -30,8 +30,8 @@ export const formLibChoices = [
     type: dependenciesType.prod,
   },
   {
-    name: 'Ract Form Hooks',
-    value: 'react-form-hooks',
+    name: 'Ract Hook Form',
+    value: 'react-hook-form',
     type: dependenciesType.prod,
   },
 ];


### PR DESCRIPTION
Hi Mohammed,
i see some issues when i try to select the react hook form, fetching is broken, after investigating i see a typo issue in the package file
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/46519034-8ed3-4567-9b5e-40c95ee3239a">
 